### PR TITLE
Match and serve requested resource dynamically

### DIFF
--- a/template/.env.example
+++ b/template/.env.example
@@ -5,7 +5,7 @@ CRM_URL_PATH=https://yourcrm.crm.dynamics.com/
 MITMPROXY_PATH=C:\\path\\to\\mitmproxy.exe
 
 # The expected URL to match/intercept from Dynamics. {PCF_NAME} is a placeholder that will be replaced with the actual component name during runtime.
-PCF_EXPECTED_PATH=/webresources/{PCF_NAME}/bundle.js
+PCF_EXPECTED_PATH=/webresources/{PCF_NAME}/
 
 # Path to your Chrome executable
 CHROME_EXE_PATH=C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe

--- a/template/dev/redirect-bundle.py
+++ b/template/dev/redirect-bundle.py
@@ -1,21 +1,31 @@
 import os
+import re
 from mitmproxy import http
 
 PCF_NAME = os.getenv("PCF_COMPONENT_NAME")
-PCF_EXPECTED_PATH = os.getenv("PCF_EXPECTED_PATH", "/webresources/{PCF_NAME}/bundle.js")
+PCF_EXPECTED_PATH = os.getenv("PCF_EXPECTED_PATH", "/webresources/{PCF_NAME}/")
 HTTP_SERVER_PORT = int(os.getenv("HTTP_SERVER_PORT", "8082"))
 
 def request(flow: http.HTTPFlow) -> None:
     if not PCF_NAME:
         return
 
-    expected_substring = PCF_EXPECTED_PATH.replace("{PCF_NAME}", PCF_NAME)
+    expected_base_path = PCF_EXPECTED_PATH.replace("{PCF_NAME}", PCF_NAME)
 
-    if expected_substring in flow.request.url:
-        print(f"🔁 Redirecting to localhost bundle.js")
+    # Use a regex to match requests for the component's web resources
+    # and capture the path of the requested resource.
+    pattern = f"{re.escape(expected_base_path)}(.*)"
+    match = re.search(pattern, flow.request.url)
+
+    if match:
+        # The resource path, e.g., "bundle.js" or "css/styles.css"
+        dynamic_path = match.group(1)
+        
+        print(f"🔁 Redirecting to localhost/{dynamic_path}")
         flow.request.host = "localhost"
         flow.request.port = HTTP_SERVER_PORT
         flow.request.scheme = "http"
-        flow.request.path = "/bundle.js"
+        # The path on the local dev server.
+        flow.request.path = f"/{dynamic_path}"
         flow.request.headers["if-none-match"] = ""
         flow.request.headers["cache-control"] = "no-cache"


### PR DESCRIPTION
Updates the redirect script to match the requested resource path dynamically using RegEx and serve from the local output directory.

This allows serving files other than `bundle.css` (for example, `css/style.css`) through the proxy.